### PR TITLE
Ensure config file exists before reading it

### DIFF
--- a/scripts/visum.sh
+++ b/scripts/visum.sh
@@ -1,3 +1,7 @@
+# Ensure config file exists, without changing its modification time
+mkdir -p ~/.config/visum/
+>> ~/.config/visum/visum.conf
+
 if [ "$1" == "" ]; then
   echo "No file path provided."
   exit 1


### PR DESCRIPTION
When used in a multi-user context, we cannot rely on the config file being created for all user by the installation script. This ensures the config folder and file exists each time the script is run.

The `>> ~/.config/visum/visum.conf` trick will create the file if it does not exists. If the file already exists it won't do anything, not even update modification times (unlike `touch`).